### PR TITLE
Add functionality to compare pd.Series and pd.Index datatypes

### DIFF
--- a/engarde/checks.py
+++ b/engarde/checks.py
@@ -253,9 +253,9 @@ def one_to_many(df, unitcol, manycol):
     ==========
     df : DataFrame
     unitcol : str
-        The column that encapulates the groups in ``manycol``.
+        The column that encapsulates the groups in ``manycol``.
     manycol : str
-        The column that must remain unique in the distict pairs
+        The column that must remain unique in the distinct pairs
         between ``manycol`` and ``unitcol``
 
     Returns
@@ -295,7 +295,18 @@ def is_same_as(df, df_to_compare, **kwargs):
     return df
 
 
-__all__ = ['is_monotonic', 'is_same_as', 'is_shape', 'none_missing',
-           'unique_index', 'within_n_std', 'within_range', 'within_set',
-           'has_dtypes', 'verify', 'verify_all', 'verify_any',
-           'one_to_many','is_same_as',]
+__all__ = [
+    'has_dtypes',
+    'is_monotonic',
+    'is_same_as',
+    'is_shape',
+    'none_missing',
+    'one_to_many',
+    'unique_index',
+    'verify',
+    'verify_all',
+    'verify_any',
+    'within_n_std',
+    'within_range',
+    'within_set',
+]

--- a/engarde/checks.py
+++ b/engarde/checks.py
@@ -272,27 +272,37 @@ def one_to_many(df, unitcol, manycol):
     return df
 
 
-def is_same_as(df, df_to_compare, **kwargs):
+def is_same_as(obj, obj_to_compare, **kwargs):
     """
-    Assert that two pandas dataframes are the equal
+    Assert that two pandas DataFrame, Index, or Series objects are the equal
 
     Parameters
     ==========
-    df : pandas DataFrame
-    df_to_compare : pandas DataFrame
+    obj : DataFrame, Index, Series
+    obj_to_compare : DataFrame, Index, Series
     **kwargs : dict
-        keyword arguments passed through to panda's ``assert_frame_equal``
+        keyword arguments passed through to panda's ``assert_frame_equal``,
+        ``assert_index_equal``, and ``assert_series_equal``
 
     Returns
     =======
-    df : DataFrame
+    obj : DataFrame, Index, Series
 
     """
     try:
-        tm.assert_frame_equal(df, df_to_compare, **kwargs)
+        if isinstance(obj, pd.DataFrame):
+            tm.assert_frame_equal(obj, obj_to_compare, **kwargs)
+        elif isinstance(obj, pd.Index):
+            tm.assert_frame_equal(obj, obj_to_compare, **kwargs)
+        elif isinstance(obj, pd.Series):
+            tm.assert_series_equal(obj, obj_to_compare, **kwargs)
+        else:
+            raise TypeError("'obj' is not a pandas DataFrame, Index, or Series")
+
     except AssertionError as exc:
-        six.raise_from(AssertionError("DataFrames are not equal"), exc)
-    return df
+        six.raise_from(AssertionError("obj are not equal"), exc)
+
+    return obj
 
 
 __all__ = [

--- a/engarde/checks.py
+++ b/engarde/checks.py
@@ -274,7 +274,7 @@ def one_to_many(df, unitcol, manycol):
 
 def is_same_as(obj, obj_to_compare, **kwargs):
     """
-    Assert that two pandas DataFrame, Index, or Series objects are the equal
+    Assert that two pandas DataFrame, Index, or Series objects are equal
 
     Parameters
     ==========

--- a/engarde/checks.py
+++ b/engarde/checks.py
@@ -293,7 +293,7 @@ def is_same_as(obj, obj_to_compare, **kwargs):
         if isinstance(obj, pd.DataFrame):
             tm.assert_frame_equal(obj, obj_to_compare, **kwargs)
         elif isinstance(obj, pd.Index):
-            tm.assert_frame_equal(obj, obj_to_compare, **kwargs)
+            tm.assert_index_equal(obj, obj_to_compare, **kwargs)
         elif isinstance(obj, pd.Series):
             tm.assert_series_equal(obj, obj_to_compare, **kwargs)
         else:

--- a/engarde/checks.py
+++ b/engarde/checks.py
@@ -282,7 +282,7 @@ def is_same_as(obj, obj_to_compare, **kwargs):
     obj_to_compare : DataFrame, Index, Series
     **kwargs : dict
         keyword arguments passed through to panda's ``assert_frame_equal``,
-        ``assert_index_equal``, and ``assert_series_equal``
+        ``assert_index_equal``, or ``assert_series_equal``
 
     Returns
     =======

--- a/engarde/decorators.py
+++ b/engarde/decorators.py
@@ -187,8 +187,18 @@ def is_same_as(df_to_compare, **assert_kwargs):
     return decorate
 
 
-__all__ = ['is_monotonic', 'is_same_as', 'is_shape', 'none_missing',
-           'unique_index', 'within_range', 'within_set', 'has_dtypes',
-           'verify', 'verify_all', 'verify_any', 'within_n_std',
-           'one_to_many','is_same_as',]
-
+__all__ = [
+    'has_dtypes',
+    'is_monotonic',
+    'is_same_as',
+    'is_shape',
+    'none_missing',
+    'one_to_many',
+    'unique_index',
+    'verify',
+    'verify_all',
+    'verify_any',
+    'within_n_std',
+    'within_range',
+    'within_set',
+]

--- a/engarde/decorators.py
+++ b/engarde/decorators.py
@@ -176,12 +176,12 @@ def _verify(func, _kind, *args, **kwargs):
     return decorate
 
 
-def is_same_as(df_to_compare, **assert_kwargs):
+def is_same_as(obj_to_compare, **assert_kwargs):
     def decorate(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             result = func(*args, **kwargs)
-            ck.is_same_as(result, df_to_compare, **assert_kwargs)
+            ck.is_same_as(result, obj_to_compare, **assert_kwargs)
             return result
         return wrapper
     return decorate

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -285,7 +285,7 @@ def test_verify_any():
         ck.verify_any(df, f, n=4)
         dc.verify_any(f, n=4)(df)
 
-def test_is_same_as():
+def test_is_same_as_dataframe():
     df = pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3]})
     df_equal = pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3]})
     df_not_equal = pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 1]})
@@ -300,7 +300,7 @@ def test_is_same_as():
         ck.is_same_as(df, df_not_equal)
         dc.is_same_as(df_not_equal)(_noop)(df)
 
-def test_is_same_as_with_kwargs():
+def test_is_same_as_with_kwargs_dataframe():
     df = pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3]})
     df_equal = pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3]})
     df_equal_float = pd.DataFrame({'A': [1.0, 2, 3], 'B': [1, 2, 3.0]})
@@ -320,3 +320,76 @@ def test_is_same_as_with_kwargs():
 
     result = dc.is_same_as(df_equal_float, check_dtype=False)(_noop)(df)
     tm.assert_frame_equal(df, result)
+
+def test_is_same_as_index():
+    assert 1 == 1
+    index = pd.Index([1, 2, 3])
+    index_equal = pd.Index([1, 2, 3])
+    index_not_equal = pd.Index([1, 2, 3.0])
+
+    result = ck.is_same_as(index, index_equal)
+    tm.assert_index_equal(index, result)
+
+    result = dc.is_same_as(index_equal)(_noop)(index)
+    tm.assert_index_equal(index, result)
+
+    with pytest.raises(AssertionError):
+        ck.is_same_as(index, index_not_equal)
+        dc.is_same_as(index_not_equal)(_noop)(index)
+
+def test_is_same_as_with_kwargs_index():
+    index = pd.Index([1, 2, 3])
+    index_equal = pd.Index([1, 2, 3])
+    index_equal_float = pd.Index([1, 2, 3.0])
+
+    result = ck.is_same_as(index, index_equal, exact=True)
+    tm.assert_index_equal(index, result)
+
+    result = dc.is_same_as(index_equal, exact=True)(_noop)(index)
+    tm.assert_index_equal(index, result)
+
+    with pytest.raises(AssertionError):
+        ck.is_same_as(index, index_equal_float, exact=True)
+        dc.is_same_as(index_equal_float, exact=True)(_noop)(index)
+
+    result = ck.is_same_as(index, index_equal_float, exact=False)
+    tm.assert_index_equal(index, result)
+
+    result = dc.is_same_as(index_equal_float, exact=False)(_noop)(index)
+    tm.assert_index_equal(index, result)
+
+def test_is_same_as_series():
+    series = pd.Series({'A': [1, 2, 3]}, index=[1, 2, 3])
+    series_equal = pd.Series({'A': [1, 2, 3]}, index=[1, 2, 3])
+    series_not_equal = pd.Series({'A': [1, 2, 3]}, index=[1, 2, 4])
+
+    result = ck.is_same_as(series, series_equal)
+    tm.assert_series_equal(series, result)
+
+    result = dc.is_same_as(series_equal)(_noop)(series)
+    tm.assert_series_equal(series, result)
+
+    with pytest.raises(AssertionError):
+        ck.is_same_as(series, series_not_equal)
+        dc.is_same_as(series_not_equal)(_noop)(series)
+
+def test_is_same_as_with_kwargs_series():
+    series = pd.Series({'A': [1, 2, 3]}, index=[1, 2, 3])
+    series_equal = pd.Series({'A': [1, 2, 3]}, index=[1, 2, 3])
+    series_equal_float = pd.Series({'A': [1, 2, 3]}, index=[1, 2, 3.0])
+
+    result = ck.is_same_as(series, series_equal, check_index_type=True)
+    tm.assert_series_equal(series, result)
+
+    result = dc.is_same_as(series_equal, check_index_type=True)(_noop)(series)
+    tm.assert_series_equal(series, result)
+
+    with pytest.raises(AssertionError):
+        ck.is_same_as(series, series_equal_float, check_index_type=True)
+        dc.is_same_as(series_equal_float, check_index_type=True)(_noop)(series)
+
+    result = ck.is_same_as(series, series_equal_float, check_index_type=False)
+    tm.assert_series_equal(series, result)
+
+    result = dc.is_same_as(series_equal_float, check_index_type=False)(_noop)(series)
+    tm.assert_series_equal(series, result)


### PR DESCRIPTION
The `is_same_as` function is a wrapper around pandas' `assert_frame_equal` method for `DataFrames`. Added functionality so `pd.Index` and `pd.Series` objects can be compared via `assert_index_equal` and `assert_series_equal` respectively.